### PR TITLE
🗃️ IDB method to subscribe on selected items changes

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@
 **/*
 !index.js
 !index.d.ts
+!react.js
+!react.d.ts

--- a/README.md
+++ b/README.md
@@ -70,72 +70,63 @@ Use with React:
 - [`useDataLinker` hook](#usedatalinker-hook)
 
 ### TypeSctipt support
-IDB come out-of-the-box with types desclaration.
-By using IDB in TS project, every data related method (exludes `deleteAll`) have a type parameters, where `T` stands for `Type` of data you operate and `K` stands for `Key` to access this data in the store.
-You can learn detailed types annotation for the concrete method by clicking `[Ref]` link in the method description in this Readme or you can explore all types stuff [on docs site](https://lr0pb.github.io/IDB.js/classes/IDB.IDB)
+IDB come out-of-the-box with types declaration.
+While using IDB in TS project, every data related method (exludes `deleteAll`) have a type parameters, where `T` stands for `Type` of data you operate and `K` stands for `Key` to access this data in the store.
+You can learn detailed types annotation for the concrete method by clicking `[Ref]` link in the method description within this Readme or you can explore all types stuff [on docs site](https://lr0pb.github.io/IDB.js/classes/IDB.IDB)
 
 # Examples
 
 ### Set items to store
 [[Ref]](https://lr0pb.github.io/IDB.js/classes/IDB.IDB.html#set) Add item to the store via `db.set(store, item | items[])` method
 ```js
-async function addAuthor(books) {
-  await db.set('authors', {
-    name: 'Agatha Christie',
-    books: []
-  });
+await db.set('authors', {
+  name: 'Agatha Christie',
+  books: [...]
+});
 
-  await db.set('authors', [
-    author1, author2, ...
-  ]);
-}
+await db.set('authors', [
+  author1, author2, ...
+]);
 ```
 
 ### Get items from store
 [[Ref]](https://lr0pb.github.io/IDB.js/classes/IDB.IDB.html#get) Get one or more items by keys with `db.get(store, key | keys[])` method
 ```js
-async function renderAuthor() {
-  const author = await db.get('author', 'Agatha Christie');
-  // {
-  //   name: 'Agatha Christie',
-  //   books: [12345, 67890, ...],
-  //   ...
-  // }
-  ...
-  const authorsBooks = await db.get('books', author.books);
-  // [
-  //   {
-  //     id: 12345,
-  //     title: `Hercule Poirot's Christmas`,
-  //     ...
-  //   },
-  //   {
-  //     id: 67890,
-  //     title: `Murder on the Orient Express`,
-  //     ...
-  //   },
-  //   ...
-  // ]
-}
+const author = await db.get('author', 'Agatha Christie');
+// {
+//   name: 'Agatha Christie',
+//   books: [12345, 67890, ...],
+//   ...
+// }
+const authorsBooks = await db.get('books', author.books);
+// [
+//   {
+//     id: 12345,
+//     title: `Hercule Poirot's Christmas`,
+//     ...
+//   },
+//   {
+//     id: 67890,
+//     title: `Murder on the Orient Express`,
+//     ...
+//   },
+//   ...
+// ]
 ```
 
 ### Get all items from store
 [[Ref]](https://lr0pb.github.io/IDB.js/classes/IDB.IDB.html#getAll) Read all items in the store with `db.getAll(store, DataReceivingCallback?)` method
 ```js
-async function renderAllBooks() {
-  const books = await db.getAll('books');
-  books.forEach((book) => {
-    renderBook(book);
-  });
-}
+const books = await db.getAll('books');
+books.forEach((book) => {
+  renderBook(book);
+});
 ```
 Additionally, you can set `DataReceivingCallback` that will be called every time new item receives from the database
 ```js
-async function renderBooksProgressive() {
-  await db.getAll('books', (book) => {
-    renderBook(book);
-  });
-}
+await db.getAll('books', (book) => {
+  renderBook(book);
+});
 ```
 > `DataReceivingCallback` function must be **sync**
 
@@ -144,7 +135,8 @@ async function renderBooksProgressive() {
 ```js
 async function addBookToAuthor(book) {
   await db.update('authors', book.author, async (author) => {
-    // this callback function receives item object and you should apply changes directly to this object
+    // this callback function receives item object, to update it,
+    // you should apply changes directly to this object
     author.books.push(book.id);
     await sendAnalytics();
   });
@@ -156,28 +148,25 @@ If you provide multiple keys, `UpdateCallback` will be called for each received 
 ### Delete items from store
 [[Ref]](https://lr0pb.github.io/IDB.js/classes/IDB.IDB.html#delete) Delete one or more items by keys with `db.delete(store, key | keys[])` method and clear all store entries with `db.deleteAll(store)` method [[Ref]](https://lr0pb.github.io/IDB.js/classes/IDB.IDB.html#deleteAll)
 ```js
-async function deleteBooks() {
-  await db.delete('books', 12345);
-  await db.delete('books', [
-    67890, 34567, ...
-  ]);
-  await db.deleteAll('author'); // authors store is still available but have no items
-}
+await db.delete('books', 12345);
+await db.delete('books', [
+  67890, 34567, ...
+]);
+await db.deleteAll('author');
+// `authors` store is still available but have zero items
 ```
 
 ### Check that store contain items
 [[Ref]](https://lr0pb.github.io/IDB.js/classes/IDB.IDB.html#has) Check if store have certain items via `db.has(store, key | keys[] | void)` or get amount of all items in the store by not passing `key` argument
 ```js
-async function addBook() {
-  const book = {
-    id: 12345,
-    title: `Hercule Poirot's Christmas`,
-    ...
-  };
-  await db.set('books', book);
-  const isBookSaved = await db.has('books', book.id); // true
-  const booksCount = await db.has('books'); // 1
-}
+const book = {
+  id: 12345,
+  title: `Hercule Poirot's Christmas`,
+  ...
+};
+await db.set('books', book);
+const isBookSaved = await db.has('books', book.id); // true
+const booksCount = await db.has('books'); // 1
 ```
 
 ### Listen for store updates
@@ -185,16 +174,14 @@ async function addBook() {
 
 To unregister callback, call returned from `db.onDataUpdate` [`UnregisterListener`](https://lr0pb.github.io/IDB.js/classes/IDB.IDB#onDataUpdate) function
 ```js
-async signForUpdates() {
-  const unregister = await db.onDataUpdate('books', async ({store, type, item}) => {
-    // item argument not presented when it was a deleting operation
-    if (type === 'set' && isNewBook(item)) {
-      await notifyUserAboutNewBookAdded(item);
-    }
-  });
-  ...
-  unregister();
-}
+const unregister = await db.onDataUpdate('books', async ({store, type, item}) => {
+  // `item` argument not presented when it was a deleting operation
+  if (type === 'set' && isNewBook(item)) {
+    await notifyUserAboutNewBookAdded(item);
+  }
+});
+...
+unregister();
 ```
 > `StoreUpdatesListener` function can be **async**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📦 IDB.js
 
-Lightweight promise-based wrapper for fast & simple access to IndexedDB API
+Lightweight promise-based wrapper for fast & simple access to IndexedDB API. With React integration ⚛️
 
 [![Latest release](https://img.shields.io/github/v/release/lr0pb/IDB.js?color=g&label=Version&logo=npm)](https://www.npmjs.com/package/@lr0pb/idb)
 [![Publish package](https://github.com/lr0pb/IDB.js/actions/workflows/publishPackage.yml/badge.svg)](https://github.com/lr0pb/IDB.js/actions/workflows/publishPackage.yml)
@@ -11,6 +11,7 @@ Lightweight promise-based wrapper for fast & simple access to IndexedDB API
 ### Table of content
 1. [Usage](#usage)
 1. [Examples](#examples)
+1. [Use with React](#use-with-react)
 1. [API](#api)
 1. [Changes](#changes)
 1. [Develop](#develop)
@@ -62,6 +63,11 @@ Operate with data:
 Other helpful methods:
 - [`has()`](#check-that-store-contain-items)
 - [`onDataUpdate()`](#listen-for-store-updates)
+
+Use with React:
+- [`IDBProvider` component](#idbprovider)
+- [`useIDB` hook](#useidb-hook)
+- [`useDataLinker` hook](#usedatalinker-hook)
 
 ### TypeSctipt support
 IDB come out-of-the-box with types desclaration.
@@ -192,10 +198,91 @@ async signForUpdates() {
 ```
 > `StoreUpdatesListener` function can be **async**
 
+# Use with React
+> React integration now in `beta`, it will be available with `2.2.0` release
+
+All React integration things can be accessed from `@lr0pb/idb/react` import
+
+### IDBProvider
+[[Ref]](https://lr0pb.github.io/IDB.js/functions/react_IDBProvider.IDBProvider.html) Place a IDB [context](https://beta.reactjs.org/learn/passing-data-deeply-with-context) provider at the top component of your app:
+```jsx
+import { IDB } from '@lr0pb/idb';
+import { IDBProvider } from '@lr0pb/idb/react';
+
+const db = new IDB('library', 2, ...);
+
+export function App({ children }) {
+  return (
+    <IDBProvider db={db}>
+      {children}
+    </IDBProvider>
+  );
+}
+```
+
+### useIDB hook
+[[Ref]](https://lr0pb.github.io/IDB.js/functions/react_IDBProvider.useIDB.html) Now you can access your IDB instance everywhere in components deeper in your tree
+
+You can use all IDB methods as usual, but pay attention that you should place all calls in either event callbacks or inside `useEffect` hook
+
+```jsx
+import { useIDB } from '@lr0pb/idb/react';
+
+export function BookInfo({ book }) {
+  const db = useIDB();
+  const addBook = async () => {
+    await db.set('books', book);
+  };
+  return (
+    <div className='book'>
+      <img src={book.image} />
+      <h3>{book.title}</h3>
+      <button onClick={addBook}>📙 Add book</button>
+    </div>
+  );
+}
+```
+
+### useDataLinker hook
+> Before `2.2.0` version release this is subject to change
+
+[[Ref]](https://lr0pb.github.io/IDB.js/functions/react_useDataLinker.useDataLinker.html) You can request items from database in your component by `useDataLinker(store, params)` hook: it will return requested items and connect to the data updates
+
+As your requested items in the store added, updated or deleted, your components will automatically updated according to this changes
+```jsx
+import { useDataLinker } from '@lr0pb/idb/react';
+
+export function BooksList() {
+  const books = useDataLinker('books', { getAll: true });
+  if (!books.length) {
+    return <h3>There are no books</h3>;
+  }
+  return (
+    {books.map((book) => {
+      return <BookInfo book={book} key={book.id} />;
+    })}
+  );
+}
+```
+`params` argument describes which items should be connected from database. As superset, it realises this interfase:
+```ts
+interface params<T, K> {
+  initial? T,
+  key?: K,
+  keys?: K[],
+  getAll?: boolean,
+}
+```
+Detailed description can be found on [docs site](https://lr0pb.github.io/IDB.js/functions/react_useDataLinker.useDataLinker.html)
+
 # API
 View whole detailed API documentation with all the types and overloads [on docs site](https://lr0pb.github.io/IDB.js/classes/IDB.IDB)
 
 # Changes
+
+### Notable changes
+- **2.2.0** Added integration with React: `IDBProvider` component, `useIDB` & `useDataLinker` hooks
+- **2.1.0** Explicitly throw errors when something goes wrong in IDB methods call
 
 > View all changes during versions in [CHANGELOG](https://github.com/lr0pb/IDB.js/tree/main/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Lightweight promise-based wrapper for fast & simple access to IndexedDB API. Wit
 ### Table of content
 1. [Usage](#usage)
 1. [Examples](#examples)
-1. [Use with React](#use-with-react)
 1. [API](#api)
 1. [Changes](#changes)
 1. [Develop](#develop)
@@ -63,11 +62,6 @@ Operate with data:
 Other helpful methods:
 - [`has()`](#check-that-store-contain-items)
 - [`onDataUpdate()`](#listen-for-store-updates)
-
-Use with React:
-- [`IDBProvider` component](#idbprovider)
-- [`useIDB` hook](#useidb-hook)
-- [`useDataLinker` hook](#usedatalinker-hook)
 
 ### TypeSctipt support
 IDB come out-of-the-box with types declaration.
@@ -185,90 +179,12 @@ unregister();
 ```
 > `StoreUpdatesListener` function can be **async**
 
-# Use with React
-> React integration now in `beta`, it will be available with `2.2.0` release
-
-All React integration things can be accessed from `@lr0pb/idb/react` import
-
-### IDBProvider
-[[Ref]](https://lr0pb.github.io/IDB.js/functions/react_IDBProvider.IDBProvider.html) Place a IDB [context](https://beta.reactjs.org/learn/passing-data-deeply-with-context) provider at the top component of your app:
-```jsx
-import { IDB } from '@lr0pb/idb';
-import { IDBProvider } from '@lr0pb/idb/react';
-
-const db = new IDB('library', 2, ...);
-
-export function App({ children }) {
-  return (
-    <IDBProvider db={db}>
-      {children}
-    </IDBProvider>
-  );
-}
-```
-
-### useIDB hook
-[[Ref]](https://lr0pb.github.io/IDB.js/functions/react_IDBProvider.useIDB.html) Now you can access your IDB instance everywhere in components deeper in your tree
-
-You can use all IDB methods as usual, but pay attention that you should place all calls in either event callbacks or inside `useEffect` hook
-
-```jsx
-import { useIDB } from '@lr0pb/idb/react';
-
-export function BookInfo({ book }) {
-  const db = useIDB();
-  const addBook = async () => {
-    await db.set('books', book);
-  };
-  return (
-    <div className='book'>
-      <img src={book.image} />
-      <h3>{book.title}</h3>
-      <button onClick={addBook}>📙 Add book</button>
-    </div>
-  );
-}
-```
-
-### useDataLinker hook
-> Before `2.2.0` version release this is subject to change
-
-[[Ref]](https://lr0pb.github.io/IDB.js/functions/react_useDataLinker.useDataLinker.html) You can request items from database in your component by `useDataLinker(store, params)` hook: it will return requested items and connect to the data updates
-
-As your requested items in the store added, updated or deleted, your components will automatically updated according to this changes
-```jsx
-import { useDataLinker } from '@lr0pb/idb/react';
-
-export function BooksList() {
-  const books = useDataLinker('books', { getAll: true });
-  if (!books.length) {
-    return <h3>There are no books</h3>;
-  }
-  return (
-    {books.map((book) => {
-      return <BookInfo book={book} key={book.id} />;
-    })}
-  );
-}
-```
-`params` argument describes which items should be connected from database. As superset, it realises this interfase:
-```ts
-interface params<T, K> {
-  initial? T,
-  key?: K,
-  keys?: K[],
-  getAll?: boolean,
-}
-```
-Detailed description can be found on [docs site](https://lr0pb.github.io/IDB.js/functions/react_useDataLinker.useDataLinker.html)
-
 # API
 View whole detailed API documentation with all the types and overloads [on docs site](https://lr0pb.github.io/IDB.js/classes/IDB.IDB)
 
 # Changes
 
 ### Notable changes
-- **2.2.0** Added integration with React: `IDBProvider` component, `useIDB` & `useDataLinker` hooks
 - **2.1.0** Explicitly throw errors when something goes wrong in IDB methods call
 
 > View all changes during versions in [CHANGELOG](https://github.com/lr0pb/IDB.js/tree/main/CHANGELOG.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lr0pb/idb",
-  "version": "2.0.5",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lr0pb/idb",
-      "version": "2.0.5",
+      "version": "2.1.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.20.12",
@@ -15,6 +15,7 @@
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-typescript": "^11.0.0",
         "@types/react": "^18.0.28",
         "chai": "^4.3.7",
         "mocha": "^10.2.0",
@@ -26,11 +27,12 @@
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^2.0.1",
         "rollup-plugin-terser": "^7.0.2",
+        "tslib": "^2.5.0",
         "typedoc": "^0.24.0-beta.2",
         "typescript": "^4.8.3"
       },
       "peerDependencies": {
-        "react": ">=17"
+        "react": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -691,6 +693,32 @@
       },
       "peerDependenciesMeta": {
         "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
           "optional": true
         }
       }
@@ -2819,6 +2847,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -3550,6 +3584,16 @@
         "deepmerge": "^4.2.2",
         "is-builtin-module": "^3.2.0",
         "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      }
+    },
+    "@rollup/plugin-typescript": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.0.0.tgz",
+      "integrity": "sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
         "resolve": "^1.22.1"
       }
     },
@@ -5115,6 +5159,12 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "dev": true
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^11.0.0",
+        "@types/chai": "^4.3.4",
+        "@types/mocha": "^10.0.1",
         "@types/react": "^18.0.28",
         "chai": "^4.3.7",
         "mocha": "^10.2.0",
@@ -757,6 +759,12 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -786,6 +794,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3622,6 +3636,12 @@
         }
       }
     },
+    "@types/chai": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
@@ -3651,6 +3671,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
+    "@types/chai": "^4.3.4",
+    "@types/mocha": "^10.0.1",
     "@types/react": "^18.0.28",
     "chai": "^4.3.7",
     "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lr0pb/idb",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "description": "📦 Lightweight promise-based wrapper for fast & simple access to IndexedDB API. With React integration ⚛️",
   "author": "lr0pb",
   "license": "MIT",
@@ -13,7 +13,11 @@
     "url": "https://github.com/lr0pb/IDB.js/issues"
   },
   "keywords": [
-    "IndexedDB", "idb", "promise", "typescript", "react"
+    "IndexedDB",
+    "idb",
+    "promise",
+    "typescript",
+    "react"
   ],
   "sideEffects": false,
   "main": "./index.js",
@@ -24,7 +28,7 @@
     "./react": "./react.js"
   },
   "scripts": {
-    "test": "set DEV=1 && npx tsc && rollup -c -w",
+    "test": "set DEV=1 && rollup -c -w",
     "replace": "npx replace '../IDB' './index' react.js react.d.ts",
     "build": "npx tsc && rollup -c && npm run replace",
     "serve": "set SERVE=1 && rollup -c -w",
@@ -39,6 +43,7 @@
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-typescript": "^11.0.0",
     "@types/react": "^18.0.28",
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
@@ -50,6 +55,7 @@
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-serve": "^2.0.1",
     "rollup-plugin-terser": "^7.0.2",
+    "tslib": "^2.5.0",
     "typedoc": "^0.24.0-beta.2",
     "typescript": "^4.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lr0pb/idb",
   "version": "2.1.0",
-  "description": "📦 Lightweight promise-based wrapper for fast & simple access to IndexedDB API",
+  "description": "📦 Lightweight promise-based wrapper for fast & simple access to IndexedDB API. With React integration ⚛️",
   "author": "lr0pb",
   "license": "MIT",
   "homepage": "https://github.com/lr0pb/IDB.js#readme",
@@ -20,7 +20,8 @@
   "module": "./index.js",
   "types": "./index.d.ts",
   "exports": {
-    ".": "./index.js"
+    ".": "./index.js",
+    "./react": "./react.js"
   },
   "scripts": {
     "test": "set DEV=1 && npx tsc && rollup -c -w",
@@ -28,7 +29,8 @@
     "build": "npx tsc && rollup -c && npm run replace",
     "serve": "set SERVE=1 && rollup -c -w",
     "doc": "npx typedoc",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "experimental": "npm publish --access public --tag experimental"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
@@ -50,5 +52,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "typedoc": "^0.24.0-beta.2",
     "typescript": "^4.8.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import { terser } from 'rollup-plugin-terser';
 import babel from '@rollup/plugin-babel';
 import dts from 'rollup-plugin-dts';
+import typescript from '@rollup/plugin-typescript';
 
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
@@ -29,17 +30,21 @@ const base = {
   plugins: []
 };
 
-const lib = isServe
-? {} : isDev
-? Object.assign(base, {
+let lib = {};
+if (!isServe && isDev) {
+  lib = {
+    input: 'src/IDB.ts',
     output: {
       file: 'www/IDB.js',
       format: 'es'
-    }
-  })
-: Object.assign(base, {
+    },
+    plugins: [typescript()]
+  };
+} else if (!isServe) {
+  lib = Object.assign(base, {
     plugins: [terser(terserArgs)]
   });
+}
 
 const react = isServe ? {} : {
   input: 'lib/react/index.js',
@@ -90,23 +95,21 @@ const tests = isDev ? {
   ]
 } : {};
 
-const server = isDev || isServe
-? Object.assign(base, {
-    plugins: [
-      copy({
-        targets: [
-          { src: 'test/__index__.html', dest: 'www', rename: 'index.html' },
-          { src: 'node_modules/mocha/mocha.css', dest: 'www' }
-        ]
-      }),
-      serve({
-        contentBase: 'www', open: true,
-        host: 'localhost', port: 3080
-      }),
-      livereload('www')
-    ]
-  })
-: {};
+if (isDev || isServe) {
+  lib.plugins.push(...[
+    copy({
+      targets: [
+        { src: 'test/__index__.html', dest: 'www', rename: 'index.html' },
+        { src: 'node_modules/mocha/mocha.css', dest: 'www' }
+      ]
+    }),
+    serve({
+      contentBase: 'www', open: true,
+      host: 'localhost', port: 3080
+    }),
+    livereload('www')
+  ]);
+}
 
 export default [
   lib,
@@ -114,5 +117,4 @@ export default [
   types,
   typesReact,
   tests,
-  server,
 ].filter((item) => Object.keys(item).length);

--- a/src/IDBTypes.ts
+++ b/src/IDBTypes.ts
@@ -29,7 +29,13 @@ export interface StoreContainment {
 /**
  * Internal type for define which methods can be called on transaction's store object
  */
-export type IDBAction = 'put' | 'get' | 'openCursor' | 'delete' | 'clear' | 'count';
+export type IDBAction =
+  | 'put'
+  | 'get'
+  | 'openCursor'
+  | 'delete'
+  | 'clear'
+  | 'count';
 /**
  * Function that call as callback in `db.update` for modifying item, should modify item object directly, without returning them
  * @param item Store's item to update
@@ -44,11 +50,14 @@ export type DataReceivingCallback = (item: any, index: number) => void;
 /**
  * Type of action that trigger data update listener call
  */
-export type DataUpdatedType = 'set' | 'delete' | 'deleteAll';
+export type DataUpdateType =
+  | 'set'
+  | 'delete'
+  | 'deleteAll';
 /**
  * Options passed to `StoreUpdatesListener` for `db.onDataUpdate` method
  */
-export interface DataUpdatedInfo {
+export interface DataUpdateInfo<K> {
   /**
    * Name of store in that changes was happened
    */
@@ -56,20 +65,27 @@ export interface DataUpdatedInfo {
   /**
    * Name of action that trigger this changes
    */
-  type: DataUpdatedType,
+  type: DataUpdateType,
   /**
    * If `type` is `set` provide key of item that was setted/updated in the store
-   * @deprecated This field will change its name to `key` in next minor release
+   * @deprecated Use `key` property instead. In few minor releases `item` will be deleted
    */
-  item?: any
+  item?: any,
+  /**
+   * Keys of items that was updated in the store, empty array if its `deleteAll` type
+   */
+  keys: K[],
 }
 /**
  * Listener that calls when some changes with data was happened in the store
  */
-export type StoreUpdatesListener = (info: DataUpdatedInfo) => Promise<void> | void;
+export type DataUpdateListener<K> = (info: DataUpdateInfo<K>) => Promise<void> | void;
 /**
  * Function to uregister `onDataUpdate` listener from the store
  */
 export type UnregisterListener = () => void;
 
+/**
+ * Listener that calls when updates happened with selected items
+ */
 export type UpdatedDataListener<T> = (items: T | void | (T | void)[]) => Promise<void> | void;

--- a/src/IDBTypes.ts
+++ b/src/IDBTypes.ts
@@ -88,4 +88,4 @@ export type UnregisterListener = () => void;
 /**
  * Listener that calls when updates happened with selected items
  */
-export type UpdatedDataListener<T> = (items: T | void | (T | void)[]) => Promise<void> | void;
+export type UpdatedDataListener<R> = (items: R) => Promise<void> | void;

--- a/src/IDBTypes.ts
+++ b/src/IDBTypes.ts
@@ -71,3 +71,5 @@ export type StoreUpdatesListener = (info: DataUpdatedInfo) => Promise<void> | vo
  * Function to uregister `onDataUpdate` listener from the store
  */
 export type UnregisterListener = () => void;
+
+export type UpdatedDataListener<T> = (items: T | void | (T | void)[]) => Promise<void> | void;

--- a/src/react/processDataUpdate.tsx
+++ b/src/react/processDataUpdate.tsx
@@ -1,5 +1,5 @@
 import { IDB } from '../IDB.js';
-import { DataUpdatedInfo } from '../IDBTypes.js';
+import { DataUpdateInfo } from '../IDBTypes.js';
 
 export interface InitialArg<T> {
   /**
@@ -38,7 +38,7 @@ export async function processDataUpdate<K>(
   db: IDB,
   store: string,
   { key, keys, getAll }: KeyArg<K> & KeysArg<K> & GetAllArg,
-  { type, item }: DataUpdatedInfo
+  { type, item }: DataUpdateInfo<void>
 ): Promise<DataUpdateResponse>
 {
   if (type === 'deleteAll') {

--- a/test/__index__.test.js
+++ b/test/__index__.test.js
@@ -8,7 +8,9 @@ import set from './set.test';
 import get from './get.test';
 import update from './update.test';
 import getAll from './getAll.test';
-import IDBdelete from './delete.test';
+// using underscore at the end because regular `delete` is reserved word
+import delete_ from './delete.test';
+import followDataUpdates from './followDataUpdates.test';
 
 // All test files import functions should be placed in this object
 // to be automatically called
@@ -18,7 +20,8 @@ const tests = {
   get,
   update,
   getAll,
-  IDBdelete,
+  delete_,
+  followDataUpdates,
 };
 
 // Test db object is stored in this container object
@@ -38,10 +41,10 @@ mocha.setup('bdd');
 before('open database', async () => {
   try {
     container.db = new IDB('database', 1, [
-      { name: 'one', index: {autoIncrement: true} },
-      { name: 'two', index: {keyPath: 'id'} },
-      { name: 'three', index: {keyPath: 'id'} },
-      { name: 'six', index: {autoIncrement: true} },
+      { name: 'one', index: { autoIncrement: true } },
+      { name: 'two', index: { keyPath: 'id' } },
+      { name: 'three', index: { keyPath: 'id' } },
+      { name: 'six', index: { autoIncrement: true } },
     ]);
   } catch (err) {
     should.not.exist(err);

--- a/test/followDataUpdates.test.js
+++ b/test/followDataUpdates.test.js
@@ -1,0 +1,152 @@
+import { assert } from 'chai';
+
+let unregister = null;
+let response = null;
+
+const items = [
+  { id: 'track1', value: 1 },
+  { id: 'track2', value: 1 },
+  { id: 'other', value: 1 },
+];
+
+async function sleep(time) {
+  await new Promise((res) => { setTimeout(res, time) });
+}
+
+export default function (container, checkStore) {
+  before('fill data to tests', async () => {
+    await container.db.deleteAll('two');
+    await container.db.set('two', items);
+    const check = await container.db.has('two', items.map((item) => item.id));
+    assert.deepEqual(check, Array(items.length).fill(true));
+  });
+
+  it('follow one item', async () => {
+    unregister = await container.db.followDataUpdates(
+      'two', 'track1', (item) => { response = item; }
+    );
+    assert.typeOf(unregister, 'function');
+  });
+
+  it('update tracked item', async () => {
+    const item = { id: 'track1', value: 2 };
+    await container.db.set('two', item);
+    await sleep(5);
+    assert.typeOf(response, 'object');
+    assert.deepEqual(response, item);
+    response = null;
+  });
+
+  it('update dedicated item', async () => {
+    response = 'notMutatedString';
+    const item = { id: 'track2', value: 2 };
+    await container.db.set('two', item);
+    await sleep(5);
+    assert.equal(response, 'notMutatedString');
+    response = null;
+  });
+
+  it('delete traked item', async () => {
+    await container.db.delete('two', 'track1');
+    await sleep(5);
+    assert.isUndefined(response);
+    response = null;
+  });
+
+  it('unregister follow listener', async () => {
+    unregister();
+    unregister = null;
+    const item = { id: 'track1', value: 3 };
+    await container.db.set('two', item);
+    await sleep(5);
+    assert.isNull(response);
+  });
+
+  it('follow multiple items', async () => {
+    unregister = await container.db.followDataUpdates(
+      'two', ['track1', 'other'], (item) => { response = item; }
+    );
+    assert.typeOf(unregister, 'function');
+  });
+
+  it('update one of followed items', async () => {
+    const item = { id: 'track1', value: 4 };
+    await container.db.set('two', item);
+    await sleep(5);
+    assert.isArray(response);
+    assert.equal(response.length, 2);
+    assert.deepEqual(response, [item, items[2]]);
+    response = null;
+  });
+
+  it('delete one of followed items', async () => {
+    await container.db.delete('two', 'track1');
+    await sleep(5);
+    assert.isArray(response);
+    assert.equal(response.length, 2);
+    assert.deepEqual(response, [undefined, items[2]]);
+    response = null;
+    unregister();
+    unregister = null;
+  });
+
+  it('follow all items as the fallback', async () => {
+    unregister = await container.db.followDataUpdates(
+      'two', undefined, (item) => { response = item; }
+    );
+    assert.typeOf(unregister, 'function');
+  });
+
+  it('update multiple items', async () => {
+    const item1 = { id: 'track1', value: 5 };
+    const item2 = { id: 'track2', value: 5 };
+    await container.db.set('two', [item1, item2]);
+    await sleep(5);
+    assert.isArray(response);
+    assert.deepEqual(response, [items[2], item1, item2]);
+    response = null;
+    unregister();
+    unregister = null;
+  });
+
+  it('explicitly follow all items', async () => {
+    unregister = await container.db.followDataUpdates(
+      'two', {getAll: true}, (item) => { response = item; }
+    );
+    assert.typeOf(unregister, 'function');
+  });
+
+  it('delete multiple items', async () => {
+    await container.db.delete('two', ['track1', 'track2']);
+    await sleep(5);
+    assert.isArray(response);
+    assert.deepEqual(response, [items[2]]);
+    response = null;
+  });
+
+  it('delete all items', async () => {
+    await container.db.deleteAll('two');
+    await sleep(5);
+    assert.isArray(response);
+    assert.equal(response.length, 0);
+    response = null;
+    unregister();
+    unregister = null;
+  });
+
+  it('follow item with number key', async () => {
+    const key = 1234;
+    unregister = await container.db.followDataUpdates(
+      'two', key, (item) => { response = item; }
+    );
+    assert.typeOf(unregister, 'function');
+    const item = { id: key, value: 1 };
+    await container.db.set('two', item);
+    await sleep(5);
+    assert.typeOf(response, 'object');
+    assert.deepEqual(response, item);
+    response = null;
+    unregister();
+    unregister = null;
+  });
+}

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -30,10 +30,10 @@ export default function (container, checkStore) {
   });
 
   it('set multimple items at once', async () => {
-    await container.db.set('two', [
-      item1, item2,
-    ]);
-    await checkStore('two', 2);
+    const items = [ item1, item2 ];
+    await container.db.set('two', items);
+    const check = await container.db.has('two', items.map((item) => item.id));
+    assert.deepEqual(check, Array(items.length).fill(true));
   });
 
   it('container.db.has for item in index store', async () => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,10 +1,15 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": [
-    "src/IDB.ts", "src/IDBTypes.ts"
+    "src/IDB.ts", "src/IDBTypes.ts",
+    "src/react/index.ts",
+    "src/react/IDBProvider.tsx",
+    "src/react/useDataLinker.tsx",
+    "src/react/processDataUpdate.tsx"
   ],
   "navigationLinks": {
-    "IDB": "/classes/IDB.IDB.html"
+    "IDB": "/classes/IDB.IDB.html",
+    "React": "/modules/react.html"
   },
   "cleanOutputDir": true,
   "out": "docs",


### PR DESCRIPTION
Since React integration have own [`processDataUpdate`](https://github.com/lr0pb/IDB.js/blob/9123f05aa37a9b95ec71892d17aad0b594bfc834/src/react/processDataUpdate.tsx#L37) function that work on top of [`db.onDataUpdate`](https://github.com/lr0pb/IDB.js#listen-for-store-updates) method and filter only events that happen for items with keys that passed to `useDataLinker` hook I consider that **this behaviour is common, so it should be included within the main functionality of IDB.**

Firstly, new behaviour introduce new type function for callbacks:
```ts
type CallbackWithUpdatedData<T> = (items: T | T[] | void) => Promise<void> | void; // Name TBD
```
And additional requirement: new method should follow updates of item with given key OR multilpe items with given keys array OR if no keys presented - follow every changes in store (work same as current `db.onDataUpdate` but call callback with all store items instead DataUpdatedInfo)

And then there are few variants to reach described behaviour:
- introduce separate method like `db.follow` or `db.subscribe` (maybe `db.subscribeToDataUpdates` even more cleaner name, but it is so long) with API like this:
```ts
async function follow<T, K>( // Name TBD
  store: string,
  callback: CallbackWithUpdatedData<T>,
  keys?: K | K[]
): Promise<UnregisterListener>
```

- include this functionality in `db.onDataUpdate` method by extending its current API:
```ts
async function onDataUpdate<T, K>(
  store: string,
  listener: StoreUpdatesListener<T> | CallbackWithUpdatedData<T>,
  mode?: 'allEvents' | 'selectedItems', // Names TBD
  keys?: K | K[]
): Promise<UnregisterListener>

type StoreUpdatesListener<T> = (info: DataUpdatedInfo<T>) => Promise<void> | void

interface DataUpdatedInfo<T> {
  store: string,
  type: 'set' | 'delete' | 'deleteAll',
  item?: T
}
```

What's better solution 🤔